### PR TITLE
Fix for 56 remove rcomp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ ADD_EXECUTABLE(
     Resources.bin
     ${CREATIVE_ENGINE_SOURCE_FILES}
     ${MODITE_SRC}
-        src/GameState/GSpiderProcess.cpp src/GameState/GSpiderProcess.h src/GameState/GEnemyProcess.cpp src/GameState/GEnemyProcess.h)
+)
 
 ProcessorCount(N)
 if(NOT N EQUAL 0)


### PR DESCRIPTION
Fix for #56
- [x] The rcomp sources are being linked in to the game.

Also removed extra rcomp-src refs