### PR TITLE
Spikes should care to collide with player

### DIFF
--- a/src/GameState/environment/GSpikesProcess.cpp
+++ b/src/GameState/environment/GSpikesProcess.cpp
@@ -23,7 +23,7 @@ GSpikesProcess::GSpikesProcess(GGameState *aGameState, TInt aIp, TFloat aX, TFlo
   mParam = aParam;
   mGameState = aGameState;
   mSprite = new GAnchorSprite(mGameState, SPIKES_PRIORITY, ENVIRONMENT_SLOT, IMG_SPIKES);
-  mSprite->cMask = STYPE_DEFAULT;
+  mSprite->cMask = STYPE_PLAYER;
   mSprite->w = mSprite->h = 24;
   mSprite->cx = -8;
   mSprite->cy = -4;


### PR DESCRIPTION
This broke due to the fixes in BSprite collision logic here:

```c
        // make sure these two sprites care about collisions vs. each other
        if (!(s->cMask & s2->type))
          continue;
        if (!(s2->cMask & s->type))
          continue;
```

It was failing as the spikes sprite cMask didn't care about the STYPE_PLAYER