### PR TITLE
261 fix level change memory fault

### DIFF
--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -101,6 +101,7 @@ void GGameState::TryAgain() {
 void GGameState::PreRender() {
   if (mNextLevel != mLevel) {
     LoadLevel(mName, mNextLevel, mNextTileMapId);
+    gViewPort->mWorldX = gViewPort->mWorldY = 0;
   }
 }
 


### PR DESCRIPTION
fix #261

reset viewport location to (0, 0) on level load

memory fault was caused by the map playfield attempting to read tiles within the viewport rectangle as defined when the previous level was exited