### PR TITLE
Fixes #277 Pause menu

### DIFF
--- a/src/GGame.cpp
+++ b/src/GGame.cpp
@@ -248,7 +248,7 @@ void GGame::Run() {
       mInventory->GameLoop();
     }
     else if (mGameMenu) {
-//      gGameEngine->GameLoop();
+      gGameEngine->GameLoop();
       mGameMenu->GameLoop();
     }
     else if (mDebugMenu) {


### PR DESCRIPTION
Run main game engine alongside the pause menu with all of it's pre/post and sprite render methods