### PR TITLE
Fixes #284 Broken LDK

### DIFF
--- a/Makefile-ldk.mk
+++ b/Makefile-ldk.mk
@@ -58,6 +58,8 @@ INCLUDE = -I $(CREATIVE_ENGINE_SOURCE_DIR) \
           -I $(GAME_SOURCE_DIR)/GameState/status \
           -I $(GAME_SOURCE_DIR)/ResetState \
           -I $(GAME_SOURCE_DIR)/MainOptionsState \
+          -I $(GAME_SOURCE_DIR)/LoadGameState \
+          -I $(GAME_SOURCE_DIR)/DebugMenuState \
           -I $(GAME_SOURCE_DIR)/
 
 


### PR DESCRIPTION
Fix LDK makefile
May require `make -f Makefile-ldk.mk cleanall`
:warning: Requires CE PR too https://github.com/ModusCreateOrg/creative-engine/pull/249