### PR TITLE
Midboss fixes

### DIFF
--- a/src/GameState/mid-bosses/GMidBossDeathProcess.cpp
+++ b/src/GameState/mid-bosses/GMidBossDeathProcess.cpp
@@ -40,7 +40,7 @@ TBool GMidBossDeathProcess::RunBefore() {
     mSprite = new BAnimSprite(ENEMY_DEATH_PRIORITY, ENEMY_DEATH_SLOT, 0, STYPE_DEFAULT);
     mSprite->x = mX;
     mSprite->y = mY;
-    mSprite->SetFlags(SFLAG_SORTPRI);
+    mSprite->SetFlags(SFLAG_BELOW);
     mGameState->AddSprite(mSprite);
     mSprite->StartAnimation(deathAnimation);
   }

--- a/src/GameState/mid-bosses/GMidBossProcess.cpp
+++ b/src/GameState/mid-bosses/GMidBossProcess.cpp
@@ -47,10 +47,6 @@ GMidBossProcess::~GMidBossProcess() {
 }
 
 TBool GMidBossProcess::RunBefore() {
-  if (mSprite->Clipped()) {
-    NewState(MB_IDLE_STATE, mSprite->mDirection);
-    return ETrue;
-  }
   switch (mState) {
     case MB_IDLE_STATE:
       return IdleState();
@@ -142,6 +138,7 @@ void GMidBossProcess::NewState(TUint16 aState, DIRECTION aDirection) {
       mSprite->cy = 8;
       mSprite->w = 44;
       mSprite->h = 24;
+      mSprite->ResetShadow();
       Revert(aDirection);
       break;
 
@@ -210,7 +207,7 @@ void GMidBossProcess::NewState(TUint16 aState, DIRECTION aDirection) {
         mDeathCounter = 10;
         for (TInt delay = 0; delay < mDeathCounter; delay++) {
           printf("DEATH SPRITE @ %d,%d\n", r.x1, r.x2);
-          auto *p = new GMidBossDeathProcess(mGameState, this, r.x1, r.y1, delay);
+          auto *p = new GMidBossDeathProcess(mGameState, this, r.x1, r.y1 - 64, delay);
           mGameState->AddProcess(p);
         }
       }


### PR DESCRIPTION
Fixes #299:
Move starting Y coord up 64px and set to always be on top

Fixes #297:
Remove code that used to set boss to idle state everytime it was fully clipped, this also was making the states of returning to top after rush attack and transition from ball to normal state not trigger. Also fixed shadow position during ball->normal state transition.