### PR TITLE
Fix palette during transition

### DIFF
--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -348,6 +348,9 @@ void GGameState::LoadLevel(const char *aName, const TInt16 aLevel, TUint16 aTile
   mDungeon = mNextDungeon;
   mTileMapId = aTileMapId;
 
+  gDisplay.renderBitmap->Clear(COLOR_TEXT_BG);
+  gDisplay.displayBitmap->Clear(COLOR_TEXT_BG);
+
   Reset(); // remove sprites and processes
   mPlayfield = mGamePlayfield = mNextGamePlayfield;
   mNextGamePlayfield = ENull;


### PR DESCRIPTION
#315 

Clear gDisplay renderBitmap and displayBitmap to COLOR_TEXT_BG

Instead of showing a frame of old display/render bitmap with new palette, should now show a frame of black screen.

Example interstitial:

![2019-12-11_08:54:33](https://user-images.githubusercontent.com/329637/70642367-f171ee80-1bf3-11ea-944b-d0e59216f674.png)
