### PR TITLE
331 safe item name access

### DIFF
--- a/src/GameState/inventory/Items.h
+++ b/src/GameState/inventory/Items.h
@@ -112,7 +112,8 @@ public:
 
   const char* &operator[](int i) {
     if( i >= SIZE || i < 0 ) {
-      return itemNamesArray[0];
+      Panic("Requested name of invalid item number %d. Valid item numbers are in range [0 - %d].\n", i, SIZE-1);
+      // return itemNamesArray[0];
     }
     return itemNamesArray[i];
   }


### PR DESCRIPTION
Item names are now accessed through a class with overloaded subscript operator: attempting to access name for an index outside of the item names array ~~returns the name for item 0, "INVALID ITEM"~~ calls Panic()

#331