### PR TITLE
Fix palette flash between dungeons

### DIFF
--- a/src/GameState/GGamePlayfield.cpp
+++ b/src/GameState/GGamePlayfield.cpp
@@ -5,7 +5,7 @@ GGamePlayfield::GGamePlayfield(BViewPort *aViewPort, TUint16 aTileMapId)
   : BMapPlayfield(aViewPort, aTileMapId, TILESET_SLOT, ETrue) {
 
   mTileMapId = aTileMapId;
-  gDisplay.SetPalette(this->mTileset, 0, 128);
+//  gDisplay.SetPalette(this->mTileset, 0, 128);
   for (TInt s = 0; s < 16; s++) {
     mGroupDone[s] = mGroupState[s] = EFalse;
   }

--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -351,9 +351,9 @@ void GGameState::LoadLevel(const char *aName, const TInt16 aLevel, TUint16 aTile
   Reset(); // remove sprites and processes
   InitRemapSlots();
   mPlayfield = mGamePlayfield = mNextGamePlayfield;
+  gDisplay.SetPalette(mGamePlayfield->GetTilesBitmap(), 0, 128);
   mNextGamePlayfield = ENull;
   GPlayer::mProcess = ENull;
-
 
   RemapSlot(mNextObjectsId, ENVIRONMENT_SLOT, IMAGE_32x32);
   RemapSlot(CHARA_HERO_BMP, PLAYER_SLOT);


### PR DESCRIPTION
#315 

only change palette just before new playfield/sprites rendered