### PR TITLE
Fixes #316 Boss being cut off

### DIFF
--- a/src/GameState/GProcess.cpp
+++ b/src/GameState/GProcess.cpp
@@ -130,10 +130,13 @@ GProcess *GProcess::Spawn(GGameState *aGameState, TInt16 mAttribute, TInt aIp, T
 
       // mid bosses
     case ATTR_MID_BOSS_ENERGY:
+      return aGameState->AddProcess(new GMidBossGenericProcess(aGameState, xx, yy, MID_BOSS_SLOT, ip, params, MID_BOSS_ENERGY_BMP_SPRITES));
     case ATTR_MID_BOSS_FIRE:
+      return aGameState->AddProcess(new GMidBossGenericProcess(aGameState, xx, yy, MID_BOSS_SLOT, ip, params, MID_BOSS_FIRE_BMP_SPRITES));
     case ATTR_MID_BOSS_EARTH:
+      return aGameState->AddProcess(new GMidBossGenericProcess(aGameState, xx, yy, MID_BOSS_SLOT, ip, params, MID_BOSS_EARTH_BROWN_BMP_SPRITES));
     case ATTR_MID_BOSS_WATER:
-      return aGameState->AddProcess(new GMidBossGenericProcess(aGameState, xx, yy, MID_BOSS_SLOT, ip, params));
+      return aGameState->AddProcess(new GMidBossGenericProcess(aGameState, xx, yy, MID_BOSS_SLOT, ip, params, MID_BOSS_WATER_BMP_SPRITES));
       break;
   }
   return ENull;

--- a/src/GameState/mid-bosses/GMidBossGenericProcess.cpp
+++ b/src/GameState/mid-bosses/GMidBossGenericProcess.cpp
@@ -137,8 +137,8 @@ static ANIMSCRIPT revertAnimation[] = {
 
 /* endregion }}} */
 
-GMidBossGenericProcess::GMidBossGenericProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute)
-    : GMidBossProcess(aGameState, aX, aY, aSlot, aIp, aAttribute) {
+GMidBossGenericProcess::GMidBossGenericProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute, TInt16 aSpriteSheet)
+    : GMidBossProcess(aGameState, aX, aY, aSlot, aIp, aAttribute, aSpriteSheet) {
   //
   NewState(MB_IDLE_STATE, DIRECTION_DOWN);
 }

--- a/src/GameState/mid-bosses/GMidBossGenericProcess.h
+++ b/src/GameState/mid-bosses/GMidBossGenericProcess.h
@@ -5,7 +5,7 @@
 
 class GMidBossGenericProcess : public GMidBossProcess {
 public:
-  GMidBossGenericProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute);
+  GMidBossGenericProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute, TInt16 aSpriteSheet);
 
   ~GMidBossGenericProcess() OVERRIDE;
 

--- a/src/GameState/mid-bosses/GMidBossProcess.cpp
+++ b/src/GameState/mid-bosses/GMidBossProcess.cpp
@@ -10,7 +10,7 @@
 const TFloat VELOCITY = 1.0;
 const TInt BOUNCE_TIME = 10; // bounce around for 10 seconds
 
-GMidBossProcess::GMidBossProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute)
+GMidBossProcess::GMidBossProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute, TInt16 aSpriteSheet)
     : GProcess(aAttribute) {
   mIp = aIp;
   mSprite = ENull;
@@ -30,7 +30,7 @@ GMidBossProcess::GMidBossProcess(GGameState *aGameState, TFloat aX, TFloat aY, T
   mSprite->w = 44;
   mSprite->h = 24;
   // This might not work if the sprite positions of the mid boss bitmaps are radically different from one another
-  mSprite->mSpriteSheet = gResourceManager.LoadSpriteSheet(MID_BOSS_FIRE_BMP_SPRITES);
+  mSprite->mSpriteSheet = gResourceManager.LoadSpriteSheet(aSpriteSheet);
   mGameState->AddSprite(mSprite);
   mSprite->SetStatMultipliers(4.0, 1.2, 10.0);
   mDeathCounter = 0;

--- a/src/GameState/mid-bosses/GMidBossProcess.h
+++ b/src/GameState/mid-bosses/GMidBossProcess.h
@@ -26,7 +26,7 @@ enum {
 
 class GMidBossProcess : public GProcess {
 public:
-  GMidBossProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute);
+  GMidBossProcess(GGameState *aGameState, TFloat aX, TFloat aY, TUint16 aSlot, TInt aIp, TUint16 aAttribute, TInt16 aSpriteSheet);
 
   ~GMidBossProcess() OVERRIDE;
 


### PR DESCRIPTION
Boss was cut off as the "water" one is wider than the others, the fix is to pass the boss' spritesheet when spawning the process, this fixes the "ball" state as well for other bosses (earth and energy) that have spikes