### PR TITLE
Fixes #367. Boss loot

### DIFF
--- a/src/GameState/mid-bosses/GMidBossProcess.cpp
+++ b/src/GameState/mid-bosses/GMidBossProcess.cpp
@@ -499,7 +499,7 @@ TBool GMidBossProcess::HitState() {
 TBool GMidBossProcess::DeathState() {
   if (mDeathCounter <= 3) {
     printf("drop $%x %d\n", mAttribute, mAttribute);
-    GItemProcess::SpawnItem(mGameState, mIp, mAttribute, mSprite->x, mSprite->y);
+    GItemProcess::SpawnItem(mGameState, mIp, mAttribute, GPlayer::mSprite->x + 32, GPlayer::mSprite->y);
     return EFalse;
   }
   // maybe drop item


### PR DESCRIPTION
Spawn items dropped by the boss on top of the player so that there's no possibility of them being out of bounds.