### PR TITLE
381 Bats takeoff/landing

### DIFF
--- a/src/GameState/enemies/GBatProcess.h
+++ b/src/GameState/enemies/GBatProcess.h
@@ -13,11 +13,18 @@ public:
   ~GBatProcess() OVERRIDE;
 
 protected:
+  TBool CanWalk(DIRECTION aDirection, TFloat aVx, TFloat aVy) OVERRIDE;
+  void NewState(TUint16 aState, DIRECTION aDirection) OVERRIDE;
   void Idle(DIRECTION aDirection) OVERRIDE;
   void Walk(DIRECTION aDirection) OVERRIDE;
   void Attack(DIRECTION aDirection) OVERRIDE;
   void Hit(DIRECTION aDirection) OVERRIDE;
   void Death(DIRECTION aDirection) OVERRIDE;
+  void Land(DIRECTION aDirection);
+
+protected:
+  TFloat mAltitude;
+  TInt mLandTimer;
 };
 
 #endif // MODITE_GBATPROCESS_H


### PR DESCRIPTION
Added takeoff/landing behavior to Bat idle state: 33% of the time upon becoming idle, Bats will fly down to the ground and wait for several seconds before taking off again. Bats only stop flapping their wings when landed.

fix #381 