### PR TITLE
Fixes #395. Disable saving in boss rooms

### DIFF
--- a/src/GGame.h
+++ b/src/GGame.h
@@ -36,11 +36,11 @@ public:
   void ToggleInGameMenu();
   void ToggleInventory();
   void ToggleDebugMenu();
+  TBool IsGameState();
   BGameEngine *CurrentState();
 
   static TBool mDebug;
 protected:
-  TBool IsGameState();
 protected:
   TInt mState;
   TInt mNextState;

--- a/src/GameMenuState/GGameMenuContainer.cpp
+++ b/src/GameMenuState/GGameMenuContainer.cpp
@@ -14,7 +14,9 @@ GGameMenuContainer::GGameMenuContainer(TInt aX, TInt aY, GGameState *aGameState)
   AddWidget((BWidget &) *new GMusicWidget());
   AddWidget((BWidget &) *new GSfxWidget());
   AddWidget((BWidget &) *new GResumeWidget());
-  AddWidget((BWidget &) *new GSaveWidget(mGameState));
+  if (gGame->IsGameState() && !((GGameState *) gGameEngine)->IsBossRoom()) {
+    AddWidget((BWidget &) *new GSaveWidget(mGameState));
+  }
   AddWidget((BWidget &) *new GQuitWidget());
 
   mTimer = 30;

--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -96,6 +96,30 @@ void GGameState::TryAgain() {
   //  NextLevel(DUNGEON_DEV, 2);
 }
 
+TBool GGameState::IsBossRoom() {
+  TInt objectCount = mGamePlayfield->mObjectCount;
+  BObjectProgram *program = mGamePlayfield->mObjectProgram;
+  for (TInt ip = 0; ip < objectCount; ip++) {
+    TUint16 op = program[ip].mCode & TUint32(0xffff);
+    switch (op) {
+      case ATTR_MID_BOSS_EARTH:
+      case ATTR_MID_BOSS_ENERGY:
+      case ATTR_MID_BOSS_FIRE:
+      case ATTR_MID_BOSS_WATER:
+      case ATTR_WIZARD_EARTH:
+      case ATTR_WIZARD_ENERGY:
+      case ATTR_WIZARD_FIRE:
+      case ATTR_WIZARD_WATER:
+      case ATTR_FINAL_BOSS:
+        return ETrue;
+      default:
+        continue;
+    }
+  }
+
+  return EFalse;
+}
+
 /*******************************************************************************
  *******************************************************************************
  *******************************************************************************/

--- a/src/GameState/GGameState.h
+++ b/src/GameState/GGameState.h
@@ -80,6 +80,8 @@ public:
 
   TUint16 MapHeight();
 
+  TBool IsBossRoom();
+
 public:
   GGamePlayfield *mGamePlayfield, *mNextGamePlayfield;
 


### PR DESCRIPTION
Do not allow players to save their game when in a room that has a boss