### PR TITLE
Fixes #426. Wizard projectiles

### DIFF
--- a/src/GameState/wizard/GWizardProcess.cpp
+++ b/src/GameState/wizard/GWizardProcess.cpp
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "GWizardProcess.h"
 #include "GWizardProjectileProcess.h"
 #include "GWizardPillarProcess.h"
@@ -460,11 +461,17 @@ TBool GWizardProcess::ProjectileState() {
   }
   if (!mStep) {
     // fire 1-3 projectiled
-    TFloat xx = mSprite->x + 32,
-           yy = mSprite->y - 32;
-    mGameState->AddProcess(new GWizardProjectileProcess(mGameState, xx, yy, 45., mType));
-    mGameState->AddProcess(new GWizardProjectileProcess(mGameState, xx, yy, 90., mType));
-    mGameState->AddProcess(new GWizardProjectileProcess(mGameState, xx, yy, 135., mType));
+    TFloat xx = mSprite->x + 16,
+           yy = mSprite->y - 16;
+
+    // Angles are in radians
+    const TFloat angleToPlayer = atan2(GPlayer::mSprite->y - yy, GPlayer::mSprite->x - xx);
+    const TFloat step = 45. * (M_PI/180);
+    const TFloat angles[3] = { angleToPlayer, angleToPlayer + step, angleToPlayer - step };
+
+    mGameState->AddProcess(new GWizardProjectileProcess(mGameState, xx, yy, angles[0], mType));
+    mGameState->AddProcess(new GWizardProjectileProcess(mGameState, xx, yy, angles[1], mType));
+    mGameState->AddProcess(new GWizardProjectileProcess(mGameState, xx, yy, angles[2], mType));
 
     
     mSprite->StartAnimation(projectileAnimation2);

--- a/src/GameState/wizard/GWizardProjectileProcess.cpp
+++ b/src/GameState/wizard/GWizardProjectileProcess.cpp
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "GWizardProjectileProcess.h"
 
 const TFloat PROJECTILE_VELOCITY = 3;
@@ -155,8 +156,9 @@ GWizardProjectileProcess::GWizardProjectileProcess(GGameState *aGameState, TFloa
   mSprite->h = 8;
   mSprite->cy = 4;
 
+  // Angles are in radians
   mSprite->vx = cos(aAngle) * PROJECTILE_VELOCITY;
-  mSprite->vy = sin(aAngle) * -PROJECTILE_VELOCITY;
+  mSprite->vy = sin(aAngle) * PROJECTILE_VELOCITY;
   aGameState->AddSprite(mSprite);
   StartProjectileAnimation();
   printf("WIZARD PROJECTILE at %f,%f\n", mSprite->x, mSprite->y);


### PR DESCRIPTION
Track the player and shoot 3 projectiles towards him that are 45deg apart, possible improvements:
- Randomize step, for instance 20-45
- Randomize number of projectiles 3-5
- Randomize attack pattern, sometimes can shoot projectiles consecutively