### PR TITLE
479 fix midboss moving during death state

### DIFF
--- a/src/GameState/mid-bosses/GMidBossProcess.cpp
+++ b/src/GameState/mid-bosses/GMidBossProcess.cpp
@@ -210,6 +210,8 @@ void GMidBossProcess::NewState(TUint16 aState, DIRECTION aDirection) {
     break;
 
   case MB_DEATH_STATE:
+    mSprite->vx = 0;
+    mSprite->vy = 0;
     Death(aDirection);
     {
       // get coordinates for explosion placement


### PR DESCRIPTION
Reset velocity when switching to death state

close #479 
