### PR TITLE
562 fix goblin snipers getting stuck in walls

### DIFF
--- a/src/GameState/GAnchorSprite.cpp
+++ b/src/GameState/GAnchorSprite.cpp
@@ -292,22 +292,27 @@ void GAnchorSprite::StartAnimationInDirection(ANIMSCRIPT* aScriptGroup[4], DIREC
   }
 }
 
-void GAnchorSprite::MoveInDirection(TFloat aSpeed, DIRECTION aDirection) {
+void GAnchorSprite::MoveInDirection(TFloat aSpeed, DIRECTION aDirection, TBool aIgnoreWallFlag) {
+  TFloat newVx = vx, newVy = vy;
   switch (aDirection) {
     case DIRECTION_UP:
-      vy = -aSpeed;
+      newVy = -aSpeed;
       break;
     case DIRECTION_DOWN:
-      vy = aSpeed;
+      newVy = aSpeed;
       break;
     case DIRECTION_LEFT:
-      vx = -aSpeed;
+      newVx = -aSpeed;
       break;
     case DIRECTION_RIGHT:
-      vx = aSpeed;
+      newVx = aSpeed;
       break;
     default:
       Panic("No move direction\n");
+  }
+  if (aIgnoreWallFlag || CanWalkInDirection(aDirection, newVx, newVy)) {
+    vx = newVx;
+    vy = newVy;
   }
 }
 

--- a/src/GameState/GAnchorSprite.h
+++ b/src/GameState/GAnchorSprite.h
@@ -121,7 +121,7 @@ public:
   static DIRECTION RotateDirection(DIRECTION aDirection, TInt aRotateClockwiseCount);
 
   void StartAnimationInDirection(ANIMSCRIPT* aScriptGroup[4], DIRECTION aDirection);
-  void MoveInDirection(TFloat aSpeed, DIRECTION aDirection);
+  void MoveInDirection(TFloat aSpeed, DIRECTION aDirection, TBool aIgnoreWallFlag = EFalse);
 
   // set the BMapPlayfield tile in map attribute
   void SetMapAttribute(TUint aAttribute);

--- a/src/GameState/player/GPlayerBulletProcess.cpp
+++ b/src/GameState/player/GPlayerBulletProcess.cpp
@@ -20,7 +20,7 @@ GPlayerBulletProcess::GPlayerBulletProcess(GGameState *aGameState, DIRECTION aDi
   mSprite = new BulletSprite(aGameState);
   mSprite->mAttackStrength = GPlayer::mAttackStrength * aMultiplier;
 
-  mSprite->MoveInDirection(GPlayer::mEquipped.mGloves ? (VELOCITY + 5) : VELOCITY, aDirection);
+  mSprite->MoveInDirection(GPlayer::mEquipped.mGloves ? (VELOCITY + 5) : VELOCITY, aDirection, ETrue);
   switch (aDirection) {
     case DIRECTION_UP:
       mSprite->w = 30;


### PR DESCRIPTION
GAnchorSprite::MoveInDirection() now checks for obstructing walls before modifying velocity. Check can be disabled.

close #562 