### PR TITLE
Don't init GPlayer twice

### DIFF
--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -1147,9 +1147,6 @@ TBool GGameState::SaveState() {
 }
 
 TBool GGameState::LoadState(const char *aGameName) {
-  GPlayer::Init();
-  GPlayer::mInventoryList.FullReset();
-
   printf("\n======= BEGIN %s =======\n", __FUNCTION__);
   BMemoryStream stream = *gSavedGameList.LoadSavedGame(aGameName);
   printf("LOAD Stream size %i\n", stream.Size());


### PR DESCRIPTION
`GPlayer::Init()` is already called in `GGameState:Init()`