### PR TITLE
Adding Dungeon Home, Dungeon1 and final boss music support

### DIFF
--- a/src/GSoundPlayer.cpp
+++ b/src/GSoundPlayer.cpp
@@ -73,8 +73,12 @@ static const TUint16 allSongs[] = {
   OVERWORLD_XM,
   BOSS_1_XM,
   BOSS_2_XM,
+  BOSS_3_XM,
+  DUNGEON_HOME_XM,
+  DUNGEON1_XM,
   DUNGEON4_XM,
-  DUNGEON9_XM
+  DUNGEON9_XM,
+  ENDING_THEME_XM
 };
 
 GSoundPlayer::~GSoundPlayer() {

--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -960,16 +960,17 @@ TBool GGameState::PlayMusicForCurrentLevel() {
 TBool GGameState::PlayLevelMusic(TInt16 aNextDungeon, TInt16 aSpawnedBoss) {
 
   TUint16 song = EMPTYSONG_XM;
-
+  printf("aNextDungeon = %i\n", aNextDungeon);
   // For levels -- bosses get their own treatment!
   if (aSpawnedBoss == -1) {
     if (aNextDungeon == 0) {
       song = OVERWORLD_XM;
     }
-
-    if (aNextDungeon >= 2 && aNextDungeon <= 4) {
-      //      song = DUNGEON4_XM;
-
+    else if (aNextDungeon == 1) {
+     song = DUNGEON_HOME_XM;
+    }
+    else if (aNextDungeon >= 2 && aNextDungeon <= 4) {
+      song = DUNGEON1_XM;
     }
     else if (aNextDungeon >= 13 && aNextDungeon <= 18) {
       song = DUNGEON4_XM;
@@ -981,8 +982,11 @@ TBool GGameState::PlayLevelMusic(TInt16 aNextDungeon, TInt16 aSpawnedBoss) {
   else {
     if (aSpawnedBoss == ATTR_MID_BOSS_WATER || aSpawnedBoss == ATTR_MID_BOSS_ENERGY || aSpawnedBoss == ATTR_MID_BOSS_EARTH || aSpawnedBoss == ATTR_MID_BOSS_FIRE) {
       song = BOSS_1_XM;
-    } else{
+    }
+    else if (aSpawnedBoss == ATTR_WIZARD_ENERGY || aSpawnedBoss == ATTR_WIZARD_WATER || aSpawnedBoss == ATTR_WIZARD_EARTH || aSpawnedBoss == ATTR_WIZARD_FIRE) {
       song = BOSS_2_XM;
+    } else {
+      song = BOSS_3_XM;
     }
   }
 

--- a/src/Resources.r
+++ b/src/Resources.r
@@ -219,6 +219,8 @@ SPRITESHEET 32x32 OW5_7_DGN_OBJECT_LAYER.bmp
 ########### SOUND :: MUSIC ###########
 PATH resources/music/
 RAW EmptySong.xm
+RAW Dungeon_Home.xm
+RAW Dungeon1.xm
 RAW Dungeon4.xm
 RAW Dungeon9.xm
 RAW GameOver.xm
@@ -227,6 +229,8 @@ RAW Overworld.xm
 RAW Logo_Reveal.xm
 RAW Boss_1.xm
 RAW Boss_2.xm
+RAW Boss_3.xm
+RAW Ending_Theme.xm
 
 ########### SOUND :: SFX ###########
 PATH resources/sound_effects/


### PR DESCRIPTION
- [x] Added [Dungeon 1 ](https://soundcloud.com/djliquidice/modite-adventure-wip-dungeon-1?in=djliquidice/sets/modite-adventure-wip-1-tracks) Track (Made it this weekend. It's only a few hours of effort so IDK if it will stick.)
- [x] Added [Final boss](https://soundcloud.com/djliquidice/modite-adventure-wip-boss-3?in=djliquidice/sets/modite-adventure-wip-1-tracks) music (Copied from an amiga-style demo track i started back in 2015)
- [x] Added https://soundcloud.com/djliquidice/modite-adventure-wip-home?in=djliquidice/sets/modite-adventure-wip-1-tracks music (Copied from Genus Countryside stage). Am considering leaving as/is or potentially changing it to the NES sample set. 
- [x] Fixed an issue with OW1 DGN2