### PR TITLE
Fixes #627 Fix camera position

### DIFF
--- a/src/GameState/GGameState.cpp
+++ b/src/GameState/GGameState.cpp
@@ -39,6 +39,7 @@ void GGameState::Init() {
   mNextObjectsId = 0;
 
   mTimer = FRAMES_PER_SECOND * 1;
+  mCameraTimer = 0;
   mGameOver = ENull;
 
   mGamePlayfield = mNextGamePlayfield = ENull;


### PR DESCRIPTION
While debugging with CLion I was able to confirm that the issue was caused by `mCameraTimer` not being set to an initial value, thus sometimes it would result in some large integer and trigger the code below (the world coords are then clamped to min/max):
```c++
  if (mCameraTimer > 0) {
    mCameraTimer--;
    TFloat cameraInertia = exp(-FACTOR * TFloat(mCameraTimer) / TARGET_PAN_DURATION);
    mWorldXX += (xx - mWorldXX) * cameraInertia;
    mWorldYY += (yy - mWorldYY) * cameraInertia;
  }
```