### PR TITLE
Fix CE branch when on MA master

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -84,7 +84,7 @@ function ensure_arch_devtools_installed {
 
 function ensure_creative_engine {
     if [[ ! -d "$CREATIVE_ENGINE_DIR" ]]; then
-        git clone https://github.com/ModusCreateOrg/creative-engine.git "$CREATIVE_ENGINE_DIR"
+        git clone https://github.com/ModusCreateOrg/creative-engine.git -b develop "$CREATIVE_ENGINE_DIR"
     fi
 }
 
@@ -260,7 +260,7 @@ function checkout_creative_engine_branch {
     MODITE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     cd "$BASE_DIR" || exit 1
     echo "The current modite branch is: $MODITE_BRANCH"
-    if (cd "$CREATIVE_ENGINE_DIR" && git checkout "$MODITE_BRANCH"); then
+    if ($MODITE_BRANCH != "master" && cd "$CREATIVE_ENGINE_DIR" && git checkout "$MODITE_BRANCH"); then
         echo "Checked out creatine-engine branch: $MODITE_BRANCH"
     elif (cd "$CREATIVE_ENGINE_DIR" && git checkout "$DEFAULT_BRANCH"); then
         echo "Checked out creatine-engine branch: $DEFAULT_BRANCH"


### PR DESCRIPTION
- Clone CE `develop` branch initially
- Checkout `develop` branch is MA is on `master` since it's the default CE branch